### PR TITLE
configure finalName

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,15 +49,15 @@ docker run -d \
 ```
 ### 3. cd into ./api/khairat-api folder
 ```
-mvn clean package -P dev;java -jar ./target/khairat-api-1.0.0.jar
+mvn clean package -P dev;java -jar ./target/khairat-api.jar
 ```
 ### 4. cd into ./api/tabung-api folder
 ```
-mvn clean package -P dev;java -jar ./target/tabung-api-1.0.0.jar
+mvn clean package -P dev;java -jar ./target/tabung-api.jar
 ```
 ### 5. cd into ./api/cadangan-api folder
 ```
-mvn clean package -P dev;java -jar ./target/cadangan-api-1.0.0.jar
+mvn clean package -P dev;java -jar ./target/cadangan-api.jar
 ```
 ### 6. cd into dashbord folder
 ```

--- a/api/cadangan-api/pom.xml
+++ b/api/cadangan-api/pom.xml
@@ -65,6 +65,7 @@
     </profiles>
 
 	<build>
+		<finalName>${project.name}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/api/khairat-api/pom.xml
+++ b/api/khairat-api/pom.xml
@@ -65,6 +65,7 @@
     </profiles>
 
 	<build>
+		<finalName>${project.name}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>

--- a/api/tabung-api/pom.xml
+++ b/api/tabung-api/pom.xml
@@ -55,6 +55,7 @@
         </profile>
     </profiles>
 	<build>
+		<finalName>${project.name}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
The following PR sets the finalName configuration to the maven projects.

by default the final jar name will follow the following convention: groupId-artifactId-version.jar

This will cause confusion down the line when we release future versions which is not 1.0.0

Therefore having finalName will make the artifacts having constant name that will be consistent with README file regardless future version upgrades.

I am setting the finalName to follow the name of the artifact, you may also like to use artifactId instead.