### PR TITLE
reduze api container size from 500+Mb to 300+Mb

### DIFF
--- a/api/cadangan-api/Dockerfile
+++ b/api/cadangan-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM openjdk:17-alpine
 
 WORKDIR /app
 

--- a/api/khairat-api/Dockerfile
+++ b/api/khairat-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM openjdk:17-alpine
 
 WORKDIR /app
 

--- a/api/tabung-api/Dockerfile
+++ b/api/tabung-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:21
+FROM openjdk:17-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
tapi kena downgrade dari open jdk 21 ke open jdk 17, os image base alphine ada untuk jdk 17 saja. 