### PR TITLE
explicitly make compiler version to 1.8

### DIFF
--- a/api/library/pom.xml
+++ b/api/library/pom.xml
@@ -9,6 +9,8 @@
 	<description>Library for E-Masjid.My</description>
 	<properties>
 		<java.version>17</java.version>
+     	<maven.compiler.source>1.8</maven.compiler.source>
+     	<maven.compiler.target>1.8</maven.compiler.target>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
Assalamualaikum wbt,

I would like to explicitly make maven compiler to target for version 1.8 for those who are using older maven/java that defaults to version 5.

Thank you