### PR TITLE
Make the masjid name visible and positioned it better

### DIFF
--- a/public-web/src/components/Home/Front.jsx
+++ b/public-web/src/components/Home/Front.jsx
@@ -1,15 +1,14 @@
-
 export default function Front() {
-
   return (
     <section className="z-10">
       <div className="sm:w-11/12 mx-auto">
         <div
           className={`py-8 sm:rounded-3xl relative w-full h-[620px] bg-homefrontbg bg-cover lg:bg-center bg-no-repeat bg-left`}
         >
-          <article className="lg:flex hidden items-end absolute top-[30%] right-0 w-[30%] border-l-2 h-1/2 px-2 border-l-white">
+          <article className="flex items-end absolute top-[30%] left-[24px] lg:left-auto lg:right-0 w-full lg:w-[30%] border-l-2 h-1/2 px-2 border-l-white">
             <div className="text-white text-[26px] w-[80%]">
-              Masjid <br/>Demo E-Masjid.My.
+              Masjid <br />
+              Demo E-Masjid.My.
             </div>
           </article>
         </div>


### PR DESCRIPTION
View from the browser in mobile viewport

<img width="240" alt="e-masjid-mobile-masjid-name" src="https://github.com/Dev4w4n/e-masjid.my/assets/60350614/baa84ced-4fdb-47e2-b69a-edfbc061943a">

=======
View from IOS Simulator iPhone 14

<img width="240" alt="e-masjid-mobile-view-masjid-name-ios" src="https://github.com/Dev4w4n/e-masjid.my/assets/60350614/a39ffd41-07f6-442a-a723-b6b3514449b2">

=======

If there are something that I need to fix for this issue, like reduce white line height or adding some dark masking on top of the background image to make the text visible, just let me know here.

For now, the fix I have done here is to make the masjid name visible and position it a little bit better.

Thank you.
