### PR TITLE
Potential fix for code scanning alert no. 2: Bad HTML filtering regexp

### DIFF
--- a/apps/tv-display/src/lib/security/security-manager.ts
+++ b/apps/tv-display/src/lib/security/security-manager.ts
@@ -67,7 +67,7 @@ class SecurityManager {
     };
 
     this.suspiciousPatterns = [
-      /<script[^>]*>.*?<\/script>/gi,
+      /<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi,
       /javascript:/gi,
       /on\w+\s*=/gi,
       /eval\s*\(/gi,


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/2](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/2)

In general, the robust fix is to avoid hand-written regexes for HTML/script detection and instead rely on a well-tested sanitization or parsing library; however, within this file we can improve the specific regex to cover common malformed script end tags that browsers accept. We should restrict the content matched inside `<script>` to avoid over-greedy patterns and allow for additional characters between `</script` and the final `>`. A commonly used improved pattern is: `/\<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi`. This still does not constitute a full HTML parser, but it closes the known gap CodeQL is pointing to.

Concretely, in `apps/tv-display/src/lib/security/security-manager.ts`, inside the `constructor`, we will replace the current script pattern on line 70:

```ts
/<script[^>]*>.*?<\/script>/gi,
```

with a more robust pattern that:

- Enforces a word boundary after `script` for the opening tag.
- Uses `[\s\S]*?` instead of `.*?` so that newlines are handled without depending on flags.
- Allows arbitrary non-`>` characters after `</script` in the closing tag, to catch `</script foo="bar">` and `</script >`.

The resulting line will be:

```ts
/<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi,
```

No new imports or helper methods are needed; we only adjust the literal regular expression in the `suspiciousPatterns` array.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
