### PR TITLE
Potential fix for code scanning alert no. 3: Bad HTML filtering regexp

### DIFF
--- a/apps/tv-display/package.json
+++ b/apps/tv-display/package.json
@@ -35,7 +35,8 @@
     "react-dom": "^19.0.0",
     "react-player": "^2.13.0",
     "tailwind-merge": "^2.0.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.5",

--- a/apps/tv-display/src/lib/security/security-manager.ts
+++ b/apps/tv-display/src/lib/security/security-manager.ts
@@ -7,7 +7,7 @@
  */
 
 import { cacheManager } from '../performance/cache-manager';
-
+import sanitizeHtml from 'sanitize-html';
 // Security configuration
 export interface SecurityConfig {
   enableCSRFProtection: boolean;
@@ -526,23 +526,30 @@ class SecurityManager {
   }
 
   private sanitizeHTML(html: string): string {
-    // Basic HTML sanitization - remove dangerous tags and attributes
-    let sanitized = html;
-
-    // Remove script tags and their content
-    sanitized = sanitized.replace(/<script[^>]*>.*?<\/script>/gi, '');
-    
-    // Remove dangerous attributes
-    sanitized = sanitized.replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '');
-    sanitized = sanitized.replace(/\sjavascript:/gi, '');
-    sanitized = sanitized.replace(/\svbscript:/gi, '');
-    
-    // Remove dangerous tags
-    const dangerousTags = ['iframe', 'object', 'embed', 'form', 'input', 'button'];
-    for (const tag of dangerousTags) {
-      const regex = new RegExp(`<${tag}[^>]*>.*?</${tag}>`, 'gi');
-      sanitized = sanitized.replace(regex, '');
-    }
+    // Robust HTML sanitization - remove dangerous tags and attributes using a well-tested library
+    const sanitized = sanitizeHtml(html, {
+      // By default, disallow script and other executable content. We explicitly list
+      // tags we want removed that were previously stripped by regexes.
+      disallowedTagsMode: 'discard',
+      allowedTags: sanitizeHtml.defaults.allowedTags.filter(
+        (tag) => !['script', 'iframe', 'object', 'embed', 'form', 'input', 'button'].includes(tag)
+      ),
+      // Remove event-handler attributes and potentially dangerous attributes while
+      // preserving common safe attributes from the default configuration.
+      allowedAttributes: Object.fromEntries(
+        Object.entries(sanitizeHtml.defaults.allowedAttributes).map(([tag, attrs]) => [
+          tag,
+          (attrs as string[]).filter(
+            (attr) =>
+              !/^on/i.test(attr) && // Remove on* handlers
+              attr !== 'style'      // Optionally strip inline styles which may contain URLs
+          )
+        ])
+      ),
+      // Only allow safe URL schemes to prevent javascript:/vbscript: URIs.
+      allowedSchemes: ['http', 'https', 'mailto', 'tel'],
+      allowProtocolRelative: false
+    });
 
     return sanitized;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/3](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/3)

In general, the safest fix is to avoid using ad‑hoc regexes for HTML sanitization and delegate to a well-tested sanitization library that knows how browsers parse HTML (including malformed constructs). For script removal specifically, the regex must at least handle variant closing tags like `</script >` and `</script foo="bar">`, and should avoid relying on `.` not matching newlines (which can also be bypassed).

The best targeted fix here, without changing surrounding functionality, is to replace the current regex-based stripping of `<script>` tags with a call to a standard sanitization library such as `dompurify` (in conjunction with `jsdom` on the server) or `sanitize-html`. This preserves behavior (“remove dangerous tags and attributes”) but does it robustly, and we can still keep the rest of the method structure intact. Within `sanitizeHTML`, we can create a minimal configuration that removes script, iframe, object, embed, and form-related elements and disallows event-handler attributes and dangerous URL schemes, matching the intent of the existing code.

Concretely for `apps/tv-display/src/lib/security/security-manager.ts`:

- Add imports for a sanitization library (e.g., `sanitize-html`).
- Rewrite `sanitizeHTML` so that instead of manually doing three regex replacements and the loop over `dangerousTags`, it delegates to `sanitizeHtml(html, options)`.
- Configure `allowedTags` and `allowedAttributes` and URL schemes so that scripts, event handlers, and `javascript:`/`vbscript:` URLs are removed, aligning with the existing logic.

If you must keep a regex-based approach and cannot add dependencies, you would need to:
- Replace the script regex with something like `/\<script\b[^>]*>[\s\S]*?<\/script[\s\S]*?>/gi`, which matches closing tags with trailing junk and across newlines.
- Update the `dangerousTags` loop to use `[\s\S]*?` instead of `.*?` so it matches content including newlines, and extend the closing tag pattern analogously.  
However, that still leaves many HTML/XSS edge cases unhandled, so using a sanitizer library is strongly preferable.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
