### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/apps/tv-display/package.json
+++ b/apps/tv-display/package.json
@@ -35,7 +35,8 @@
     "react-dom": "^19.0.0",
     "react-player": "^2.13.0",
     "tailwind-merge": "^2.0.0",
-    "zustand": "^4.4.7"
+    "zustand": "^4.4.7",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@cloudflare/next-on-pages": "^1.13.5",


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/4](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/4)

In general, to fix incomplete multi‑character sanitization you either (a) use a well‑tested sanitization library that properly parses HTML, or (b) ensure that multi‑character patterns are handled so they cannot reappear after replacement, e.g., by repeatedly applying the replacement until no further changes occur, or by simplifying the sanitization strategy to work at the character level instead of trying to parse HTML with a single regex.

Here, the safest and most targeted fix, without changing the overall behavior of `sanitizeHTML`, is to replace the brittle single‑regex script removal with a well‑supported HTML sanitizer that removes script elements and dangerous attributes. Since we cannot refactor the rest of the application and are allowed to add well‑known libraries, we can import a library such as `sanitize-html` and delegate the heavy lifting to it. We’ll configure `sanitize-html` to drop `<script>` and other dangerous tags and attributes, mirroring (and improving upon) the current intent. Concretely in `apps/tv-display/src/lib/security/security-manager.ts`, we will:

- Add an import for `sanitize-html`.
- Replace the body of `sanitizeHTML` so that it calls `sanitizeHtml(html, options)` instead of using manual regexes.
- Configure the sanitizer to disallow script and other dangerous elements and event handler attributes; to preserve the rest of the HTML structure; and to remain as functionally close as possible to the existing behavior.

This avoids the multi‑character replacement bug entirely, because the library parses HTML and removes elements structurally rather than by string substitution.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
