### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL scheme check

### DIFF
--- a/apps/tv-display/src/lib/security/security-manager.ts
+++ b/apps/tv-display/src/lib/security/security-manager.ts
@@ -635,11 +635,18 @@ class SecurityManager {
       const target = event.target as HTMLElement;
       
       // Check for suspicious JavaScript execution attempts
-      if (target.getAttribute('onclick') || target.getAttribute('href')?.startsWith('javascript:')) {
+      const href = target.getAttribute('href');
+      const normalizedHref = href ? href.trim().toLowerCase() : '';
+      if (
+        target.getAttribute('onclick') ||
+        normalizedHref.startsWith('javascript:') ||
+        normalizedHref.startsWith('data:') ||
+        normalizedHref.startsWith('vbscript:')
+      ) {
         this.logSecurityEvent('xss_attempt', 'high', 'suspicious_click', {
           tagName: target.tagName,
           onclick: target.getAttribute('onclick'),
-          href: target.getAttribute('href')
+          href: href
         }, true);
         
         event.preventDefault();


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/9](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/9)

In general, to fix incomplete URL scheme checks you should normalize the URL (trim and lower‑case) and then reject or flag any scheme capable of executing code, including at least `javascript:`, `data:`, and `vbscript:`. The same normalization logic should be reused consistently to avoid case and whitespace bypasses.

For this specific file, the minimal, non‑breaking change is to extend the existing `href` scheme check in `setupSecurityMonitoring()` to also treat `data:` and `vbscript:` links as suspicious. To keep the logic readable and robust, we should normalize the `href` string (trim and lower‑case) before checking, and then test for `.startsWith('javascript:')`, `.startsWith('data:')`, or `.startsWith('vbscript:')`. This can be done directly inline without adding new methods or imports, keeping behavior otherwise identical: we still log the same security event and prevent/stop propagation when any of these schemes are detected.

Concretely, edit `apps/tv-display/src/lib/security/security-manager.ts` inside `setupSecurityMonitoring()`, around lines 634–647. Replace the existing condition that checks `target.getAttribute('href')?.startsWith('javascript:')` with logic that retrieves the href, normalizes it, and checks for any of the three dangerous schemes. No new imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
