### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete URL substring sanitization

### DIFF
--- a/apps/tv-display/src/lib/performance/index.ts
+++ b/apps/tv-display/src/lib/performance/index.ts
@@ -123,13 +123,25 @@ export const contentOptimizations = {
    */
   optimizeVideo: (src: string) => {
     // For YouTube videos, use high quality and disable related videos
-    if (src.includes('youtube.com') || src.includes('youtu.be')) {
+    try {
       const url = new URL(src);
-      url.searchParams.set('quality', 'hd1080');
-      url.searchParams.set('rel', '0');
-      url.searchParams.set('modestbranding', '1');
-      url.searchParams.set('controls', '0');
-      return url.toString();
+      const hostname = url.hostname.toLowerCase();
+      const allowedYouTubeHosts = [
+        'youtube.com',
+        'www.youtube.com',
+        'm.youtube.com',
+        'youtu.be'
+      ];
+
+      if (allowedYouTubeHosts.includes(hostname)) {
+        url.searchParams.set('quality', 'hd1080');
+        url.searchParams.set('rel', '0');
+        url.searchParams.set('modestbranding', '1');
+        url.searchParams.set('controls', '0');
+        return url.toString();
+      }
+    } catch {
+      // If the URL is invalid, fall through and return the original src
     }
     
     return src;


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/10](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/10)

In general, instead of testing `url.includes('youtube.com')`, the URL should be parsed and its `hostname` compared against a whitelist of allowed YouTube hostnames. This ensures that `youtube.com` appears in the actual host portion of the URL, not just anywhere in the string, and avoids matching attacker-controlled domains that merely contain `youtube.com` as a substring.

For this specific code in `apps/tv-display/src/lib/performance/index.ts`, the best targeted fix is:

- Parse `src` with the standard `URL` constructor inside a `try/catch` block, to avoid throwing on invalid URLs.
- Extract the `hostname` and normalize it to lowercase.
- Define a small whitelist of allowed hostnames such as `['youtube.com', 'www.youtube.com', 'm.youtube.com', 'youtu.be']`.
- Only apply the YouTube-specific query parameters when `hostname` is in that whitelist.
- If parsing fails or the host is not allowed, simply return `src` unchanged.

This keeps the existing functionality for legitimate YouTube URLs (they still get `quality=hd1080`, `rel=0`, etc.), but avoids treating arbitrary URLs that merely contain the substring `youtube.com` as YouTube videos. All changes are confined to the `optimizeVideo` function in the shown file, and no additional imports are needed since `URL` is a standard global in modern browsers and Node.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
