### PR TITLE
Potential fix for code scanning alert no. 11: Incomplete URL substring sanitization

### DIFF
--- a/apps/tv-display/tests/performance/animation.spec.ts
+++ b/apps/tv-display/tests/performance/animation.spec.ts
@@ -391,7 +391,15 @@ test.describe('TV Display Performance - 60fps Animation Tests', () => {
 
         videoElements.forEach(iframe => {
           const src = (iframe as HTMLIFrameElement).src;
-          if (src.includes('youtube-nocookie.com')) optimizations.hasNoCookie = true;
+          try {
+            const url = new URL(src, window.location.href);
+            const hostname = url.hostname;
+            if (hostname === 'youtube-nocookie.com' || hostname.endsWith('.youtube-nocookie.com')) {
+              optimizations.hasNoCookie = true;
+            }
+          } catch {
+            // Ignore invalid URLs
+          }
           if (src.includes('autoplay=1')) optimizations.hasAutoplay = true;
           if (src.includes('modestbranding=1')) optimizations.hasModestBranding = true;
           if (src.includes('hd=1') || src.includes('quality=hd')) optimizations.hasHdQuality = true;


### PR DESCRIPTION
Potential fix for [https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/11](https://github.com/Dev4w4n/e-masjid.my/security/code-scanning/11)

In general, to fix incomplete URL substring sanitization, the URL should be parsed and checks should be performed on its structured components (such as `hostname` or `origin`) instead of using raw string `includes` on the whole URL. This eliminates cases where the target substring appears in the path, query, or as part of another domain.

In this specific test, we want to know whether an iframe is actually loaded from the `youtube-nocookie.com` host (or subdomains) rather than just containing that string somewhere. The best fix is to parse the iframe `src` with the standard `URL` constructor inside the browser context (`page.evaluate` callback) and then inspect `url.hostname`. We should treat `*.youtube-nocookie.com` as valid and avoid false positives such as `https://notyoutube-nocookie.com.example.com/...`. To preserve existing intent but make it precise, we can set `hasNoCookie` to `true` when the parsed hostname is exactly `youtube-nocookie.com` or ends with `.youtube-nocookie.com`. This requires only edits inside the `page.evaluate` function body, using the built‑in `URL` class that is already available in browsers, with no new imports.

Concretely, in `apps/tv-display/tests/performance/animation.spec.ts`, around lines 382–398, replace the direct substring check `if (src.includes('youtube-nocookie.com')) optimizations.hasNoCookie = true;` with code that constructs `new URL(src, window.location.href)` and then checks `hostname === 'youtube-nocookie.com' || hostname.endsWith('.youtube-nocookie.com')`. Wrap the parsing in a `try/catch` so malformed URLs do not break the test. No other functionality needs to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
